### PR TITLE
check if-condition in GitHub Actions

### DIFF
--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -1,0 +1,37 @@
+name: Test
+
+on:
+  pull_request:
+    branches: [ master ]
+    paths:
+      - .github/workflows/debug.yml
+  push:
+    branches: [ master ]
+    paths:
+      - .github/workflows/debug.yml
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Debug
+    steps:
+      - uses: actions/checkout@v3
+      - name: "true && $${{ false }}" # executed
+        if: true && ${{ false }}
+        run: echo "true && false"
+
+      - name: "true && false" # not executed
+        if: true && false
+        run: echo "true && false"
+
+      - name: "false" # not executed
+        if: false
+        run: echo "false"
+
+      - name: "$${{ false }}" # not executed
+        if: ${{ false }}
+        run: echo "${{ false }}"
+
+      - name: "$${{ true && false }}" # not executed
+        if: ${{ true && false }}
+        run: echo "${{ true && false }}"


### PR DESCRIPTION
GitHub Actions Result:
https://github.com/zawakin/langchain/actions/runs/5912498589/job/16035967412?pr=1

`true && ${{ false }}` was evaluated as `true` because `${{ false }}` is a string of `"false"`.

I really believe it isn't consistent for the fact the step with `if: ${{ false }}` is skipped...

<img width="610" alt="image" src="https://github.com/zawakin/langchain/assets/13769670/93379997-2a1a-4b42-b6cc-56799cda9c94">